### PR TITLE
fix: wait for loop subnodes before next iteration

### DIFF
--- a/api/core/workflow/graph_engine/graph_engine.py
+++ b/api/core/workflow/graph_engine/graph_engine.py
@@ -85,6 +85,11 @@ class GraphEngineThreadPool(ThreadPoolExecutor):
         if self.submit_count > self.max_submit_count:
             raise ValueError(f"Max submit count {self.max_submit_count} of workflow thread pool reached.")
 
+    def wait_for_all_tasks_done(self) -> None:
+        """Block until all submitted tasks have completed."""
+        while self.submit_count > 0:
+            time.sleep(0.01)
+
 
 class GraphEngine:
     workflow_thread_pool_mapping: dict[str, GraphEngineThreadPool] = {}

--- a/api/core/workflow/nodes/loop/loop_node.py
+++ b/api/core/workflow/nodes/loop/loop_node.py
@@ -398,6 +398,8 @@ class LoopNode(BaseNode):
             else:
                 yield self._handle_event_metadata(event=cast(InNodeEvent, event), iter_run_index=current_index)
 
+        graph_engine.thread_pool.wait_for_all_tasks_done()
+
         # Remove all nodes outputs from variable pool
         for node_id in loop_graph.node_ids:
             variable_pool.remove([node_id])


### PR DESCRIPTION
## Summary
- ensure thread pool waits until all tasks finish
- block loop node iteration until child nodes complete

## Testing
- `pytest tests/unit_tests/core/workflow/test_workflow_cycle_manager.py` *(fails: ModuleNotFoundError: No module named 'pydantic_extra_types')*


------
https://chatgpt.com/codex/tasks/task_e_68933fb914a88327b8e11e3b7d33e83f